### PR TITLE
Use http-server from npm install of python3 http.server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,12 @@ FROM ubuntu
 RUN     apt-get update
 RUN     apt-get install -y python3
 
+# Install npm and http-server
+RUN     apt-get install -y npm
+RUN     npm install http-server -g
+
 ADD www/ www/
 
 WORKDIR www/
 
-CMD ["/usr/bin/python3", "-m", "http.server"]
+CMD ["http-server", "-p", "8000"]


### PR DESCRIPTION
This PR switches our web server to use http-server from npm install of python3 http.server. This should be faster and more stable.